### PR TITLE
Fix `make build` error

### DIFF
--- a/buildchain/.eslintrc
+++ b/buildchain/.eslintrc
@@ -7,7 +7,8 @@
     "sourceType": "module"
   },
   "rules": {
-    "no-undef": "off"
+    "no-undef": "off",
+    "@typescript-eslint/no-empty-function": "off"
   },
   "env": {
     "browser": true,

--- a/buildchain/tsconfig.json
+++ b/buildchain/tsconfig.json
@@ -27,7 +27,7 @@
     "target": "esnext",
     "types": ["vite/client"],
     "typeRoots": [
-      "node_modules/@types"
+      "./node_modules/@types","./node_modules"
     ]
   },
   "include": [

--- a/docker-config/node-dev-vite/Dockerfile
+++ b/docker-config/node-dev-vite/Dockerfile
@@ -1,4 +1,4 @@
-FROM nystudio107/node-dev-base:16-alpine
+FROM nystudio107/node-dev-base:20-alpine
 
 WORKDIR /var/www/project/
 


### PR DESCRIPTION
This PR fixes an issue with `make build` that would cause it to error with:

```
error TS2688: Cannot find type definition file for 'vite/client'.
  The file is in the program because:
    Entry point of type library 'vite/client' specified in compilerOptions

  tsconfig.json:28:15
    28     "types": ["vite/client"],
                     ~~~~~~~~~~~~~
    File is entry point of type library specified here.

```
